### PR TITLE
fix dockerfile to directly install prod dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.9-alpine
 
-COPY prod-requirements.txt /tmp/
 COPY dist/terraform_registry_api-*-py3-none-any.whl /tmp/
-RUN pip install -r /tmp/prod-requirements.txt && \
+RUN pip install flask==1.1.2 && \
+    pip install connexion==2.7.0 && \
+    pip install waitress==2.0.0 && \
     pip install /tmp/terraform_registry_api*.whl
 
 CMD [ "/usr/local/bin/waitress-serve", "--call", "terraform_registry_api.registry:create_app" ]

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ run:
 	python3 terraform_registry_api/registry.py
 
 prod-run: production
-	docker run -d -p 8080 test:latest
+	docker run -d -p 8080:8080 test:latest
 
 production: build test
 	docker build \

--- a/prod-requirements.txt
+++ b/prod-requirements.txt
@@ -1,3 +1,0 @@
-flask==1.1.2
-connexion==2.7.0
-waitress==2.0.0


### PR DESCRIPTION
Codacy suggests that using requirements in Dockerfuiles can be problematic and errorprone so install them at specific versions directly